### PR TITLE
bug: need to test against Box first

### DIFF
--- a/tests/test_box_v2_upgrades.py
+++ b/tests/test_box_v2_upgrades.py
@@ -30,10 +30,16 @@ def test_proxy_upgrades():
     box_v2 = BoxV2.deploy(
         {"from": account},
     )
+
+    proxy_box = Contract.from_abi("Box", proxy.address, Box.abi)
+    with pytest.raises(AttributeError, ):
+            proxy_box.increment({"from": account})
+
+    box_v2 = BoxV2.deploy( {"from": account} )
+    upgrade(get_account(), proxy, box_v2, proxyAdminContract=proxy_admin)
     proxy_box = Contract.from_abi("BoxV2", proxy.address, BoxV2.abi)
-    with pytest.raises(exceptions.VirtualMachineError):
-        proxy_box.increment({"from": account})
-    upgrade(account, proxy, box_v2, proxy_admin_contract=proxy_admin)
+
+    
     assert proxy_box.retrieve() == 0
     proxy_box.increment({"from": account})
     assert proxy_box.retrieve() == 1


### PR DESCRIPTION
You're testing against BoxV2 for the existence of "increment". You need to test first against Box.  That is your intention.