### PR TITLE
encode_function_data fails bug when initializer has no args

### DIFF
--- a/scripts/helpful_scripts.py
+++ b/scripts/helpful_scripts.py
@@ -34,10 +34,11 @@ def encode_function_data(initializer=None, *args):
     Returns:
         [bytes]: Return the encoded bytes.
     """
-    if len(args) == 0 or not initializer:
-        return eth_utils.to_bytes(hexstr="0x")
-    else:
-        return initializer.encode_input(*args)
+    if not len(args): args = b''
+
+    if initializer: return initializer.encode_input(*args)
+
+    return b''
 
 
 def upgrade(


### PR DESCRIPTION
Initializers don't necessarily need any args.
Also no need to call:
`    eth_utils.to_bytes(hexstr="0x")
`
because it just equals:
`   b''`
